### PR TITLE
node.go: Replace Close() with Release()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-*.wasm
+*.wasmcmd/app/app
+app.wasm
+/cmd/app/app

--- a/node.go
+++ b/node.go
@@ -39,7 +39,7 @@ func (e *NodeBase) JSRef() js.Ref {
 func (e *NodeBase) Remove() {
 	e.ParentNode().RemoveChild(e)
 	for _, c := range e.callbacks {
-		c.Close()
+		c.Release()
 	}
 	e.callbacks = nil
 }


### PR DESCRIPTION
This change replaces the Close() call on event callbacks with Release() which is required in tip Go.