### PR TITLE
Add element.RemoveAttribute method - fixes #17

### DIFF
--- a/element.go
+++ b/element.go
@@ -44,6 +44,10 @@ func (e *Element) GetAttribute(k string) js.Value {
 	return e.v.Call("getAttribute", k)
 }
 
+func (e *Element) RemoveAttribute(k string) js.Value {
+	return e.v.Call("removeAttribute", k)
+}
+
 func (e *Element) Style() *Style {
 	return &Style{v: e.v.Get("style")}
 }


### PR DESCRIPTION
Add RemoveElement method.  

Tested locally using 'disabled' attribute e.g.

```
// DisableButton disables a button
func DisableButton(id string) {
	dom.GetDocument().GetElementById(id).SetAttribute("disabled", "true")
}

// EnableButton enables a button
func EnableButton(id string) {
	dom.GetDocument().GetElementById(id).RemoveAttribute("disabled")
}
```

