### PR TITLE
Make position a real string, when passed to syscall/js

### DIFF
--- a/element.go
+++ b/element.go
@@ -286,5 +286,5 @@ func (e *Element) AttachShadow(opts AttachShadowOpts) *ShadowRoot {
 
 // InsertAdjacentElement inserts a given element node at a given position relative to the element it is invoked upon.
 func (e *Element) InsertAdjacentElement(position Position, newElement *Element) js.Value {
-	return e.v.Call("insertAdjacentElement", position, newElement.v)
+	return e.v.Call("insertAdjacentElement", string(position), newElement.v)
 }


### PR DESCRIPTION
Sorry another update, it seems syscall/js doesn't like the Position type, we need to convert to string.