### PR TITLE
Avoid non-json content conflict in storage on cmd/app/main.go

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -55,11 +55,14 @@ func main() {
 		Text string  `json:"text"`
 	}
 
-	var (
-		stor       = storage.Local()
-		mu         sync.Mutex
-		sats       []Sat
+	const (
 		storPrefix = "go-wasm-example-"
+	)
+
+	var (
+		stor = storage.Local()
+		mu   sync.Mutex
+		sats []Sat
 	)
 
 	addSatRaw := func(r, orb, hper float64, s string) {

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/rand"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -55,9 +56,10 @@ func main() {
 	}
 
 	var (
-		stor = storage.Local()
-		mu   sync.Mutex
-		sats []Sat
+		stor       = storage.Local()
+		mu         sync.Mutex
+		sats       []Sat
+		storPrefix = "go-wasm-example-"
 	)
 
 	addSatRaw := func(r, orb, hper float64, s string) {
@@ -74,7 +76,7 @@ func main() {
 	addSat := func(r, orb, hper float64, s string) {
 		if stor != nil {
 			sat := JSat{R: r, Orb: orb, HPer: hper, Text: s}
-			id := strconv.Itoa(stor.Length() + 1)
+			id := storPrefix + strconv.Itoa(stor.Length()+1)
 			if err := storage.SetItemJSON(stor, id, sat); err != nil {
 				panic(err)
 			}
@@ -92,7 +94,11 @@ func main() {
 	if stor != nil {
 		for i := 0; i < stor.Length(); i++ {
 			key := stor.Key(i)
+			if !strings.HasPrefix(key, storPrefix) {
+				continue
+			}
 			var s JSat
+			fmt.Println(stor, key, &s)
 			if err := storage.GetItemJSON(stor, key, &s); err != nil {
 				panic(err)
 			}

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -101,7 +101,6 @@ func main() {
 				continue
 			}
 			var s JSat
-			fmt.Println(stor, key, &s)
 			if err := storage.GetItemJSON(stor, key, &s); err != nil {
 				panic(err)
 			}


### PR DESCRIPTION
Ensure that cmd/app/main.go uses a prefix in storage to avoid conflict with non-json content

Closes #36 

Signed-off-by: Ricardo Seriani <ricardo.seriani@gmail.com>